### PR TITLE
Fix: NPE on CSV export

### DIFF
--- a/src/main/java/at/favre/tools/rocketexporter/converter/SlackCsvFormat.java
+++ b/src/main/java/at/favre/tools/rocketexporter/converter/SlackCsvFormat.java
@@ -17,10 +17,12 @@ public class SlackCsvFormat implements ExportFormat {
             writer = new BufferedWriter(new OutputStreamWriter(outputStream, StandardCharsets.UTF_8));
 
             for (Message normalizedMessage : messages) {
+                String message = normalizedMessage.getMessage();
+                message = message == null ? "" : message.replaceAll("\"", "\\\\\"");
                 writer.write("\"" + normalizedMessage.getTimestamp().getEpochSecond() + "\"," +
                         "\"" + normalizedMessage.getChannel() + "\"," +
                         "\"" + normalizedMessage.getUsername() + "\"," +
-                        "\"" + normalizedMessage.getMessage().replaceAll("\"", "\\\\\"") + "\"" +
+                        "\"" + message + "\"" +
                         "\n");
             }
             writer.flush();

--- a/src/test/java/at/favre/tools/rocketexporter/converter/SlackCsvFormatTest.java
+++ b/src/test/java/at/favre/tools/rocketexporter/converter/SlackCsvFormatTest.java
@@ -19,13 +19,15 @@ public class SlackCsvFormatTest {
         exportFormat.export(
                 List.of(
                         new Message("m1", "u1", "c1", EPOCH),
-                        new Message("m2", "u2", "c3", EPOCH.plusSeconds(1))
+                        new Message("m2", "u2", "c3", EPOCH.plusSeconds(1)),
+                        new Message(null, "u3", "c3", EPOCH)
                 ),
                 bout);
 
         String out = bout.toString();
 
         assertEquals("\"0\",\"c1\",\"u1\",\"m1\"\n" +
-                "\"1\",\"c3\",\"u2\",\"m2\"\n", out);
+                "\"1\",\"c3\",\"u2\",\"m2\"\n" +
+                "\"0\",\"c3\",\"u3\",\"\"\n", out);
     }
 }


### PR DESCRIPTION
Check for null message before calling replaceAll to prevent NullPointerException. This could happen if a channel has no message and could break the workflow when exporting all channels.